### PR TITLE
Since some tabs have been removed, if last visited tab of the user is…

### DIFF
--- a/src/js/controllers/modals/enrich.js
+++ b/src/js/controllers/modals/enrich.js
@@ -412,8 +412,11 @@ angular.module('miller').controller('EnrichModalCtrl', function ($timeout, $scop
   }
 
 
-
-  $scope.setTab(localStorageService.get('lasttabname') || 'favourite');
+  var initialTab = localStorageService.get('lasttabname') || 'favourite';
+  if (Object.keys($scope.tabs).findIndex(function (t) { return t === initialTab; }) === -1) {
+    initialTab = 'favourite';
+  }
+  $scope.setTab(initialTab);
 
 
 });


### PR DESCRIPTION
… one of the one removed, this will create an error and prevent the modal to open